### PR TITLE
Totals now add to goals, and goals can be reset without an intermediate step.

### DIFF
--- a/challenges/challenge.js
+++ b/challenges/challenge.js
@@ -190,11 +190,11 @@ class Challenge {
             this.displayName +
             ' (ID ' +
             this.objectID +
-            ') has ended! Post your total using ' +
+            ') has ended! Post your total using `' +
             config.cmd_prefix +
             'total ' +
             this.objectID +
-            ' <total> to be included in the summary.' +
+            ' <total>` to be included in the summary.' +
             userList
         );
       }

--- a/challenges/sprint.js
+++ b/challenges/sprint.js
@@ -93,20 +93,20 @@ class Sprint extends Challenge {
       const channelObject = client.channels.get(this.hookedChannels[i]);
       let timeString = 'minutes';
       if (this.duration == 1) {
-        timeString = 'minute'
+        timeString = 'minute';
       }
       channelObject.send(
-        this.displayName +
-        ' (ID ' +
-        this.objectID +
-        ', ' +
-        this.duration +
-        ' ' +
-        timeString +
-        ') starts now! Race to ' +
-        this.goal +
-        ' words!' +
-        userList
+          this.displayName +
+          ' (ID ' +
+          this.objectID +
+          ', ' +
+          this.duration +
+          ' ' +
+          timeString +
+          ') starts now! Race to ' +
+          this.goal +
+          ' words!' +
+          userList
       );
     }
     this.state = 1;

--- a/goals/goals.js
+++ b/goals/goals.js
@@ -244,19 +244,49 @@ class Goals {
   /**
    * Resets a user's goal.
    * @param {Object} msg - The message that ran this function.
+   * @param {String} suffix - Information after the bot command.
    */
-  resetGoal(msg) {
+  resetGoal(msg, suffix) {
     if (!(msg.author.id in goallist.goalList)) {
       msg.channel.send(
           msg.author +
           ', you have not yet set a goal for today. Use `!set <goal>` to do so.'
       );
     } else {
-      conn.collection('goalDB').remove({authorID: msg.author.id});
-      delete goallist.goalList[msg.author.id];
-      msg.channel.send(
-          msg.author + ', you have successfully reset your daily goal.'
-      );
+      const args = suffix.split(' ');
+      const newGoal = args.shift();
+      logger.info(newGoal);
+      let newType = args.join(' ');
+      if (newType == '') {
+        newType = 'words';
+      }
+      if (suffix === undefined || !(Number.isInteger(parseInt(newGoal)))) {
+        conn.collection('goalDB').remove({authorID: msg.author.id});
+        delete goallist.goalList[msg.author.id];
+        msg.channel.send(
+            msg.author + ', you have successfully reset your daily goal.'
+        );
+      } else {
+        if (newType == goallist.goalList[msg.author.id].goalType) {
+          goallist.goalList[msg.author.id].goal = newGoal;
+          msg.channel.send(
+              msg.author +
+              ', you have written **' +
+              goallist.goalList[msg.author.id].written +
+              '** ' +
+              goallist.goalList[msg.author.id].goalType +
+              ' of your **' +
+              goallist.goalList[msg.author.id].goal +
+              '**-' +
+              goallist.goalList[msg.author.id].goalType.slice(0, -1) +
+              ' goal.'
+          );
+        } else {
+          conn.collection('goalDB').remove({authorID: msg.author.id});
+          delete goallist.goalList[msg.author.id];
+          this.setGoal(msg, suffix);
+        }
+      }
     }
   }
   /**

--- a/index.js
+++ b/index.js
@@ -303,7 +303,18 @@ const cmdList = {
     process: function(client, msg, suffix) {
       const raptorRoll = challenges.addTotal(msg, suffix);
       if (raptorRoll) {
-        // goals.updateGoal(msg, suffix, false);
+        slice = suffix.split(' ');
+        totalNumber = slice[1];
+        totalType = slice[2];
+        if (msg.author.id in goallist.goalList) {
+          authorGoalType = goallist.goalList[msg.author.id].goalType;
+          if (totalType === undefined) {
+            totalType = 'words';
+          }
+          if (totalType == authorGoalType) {
+            goals.updateGoal(msg, totalNumber, false);
+          }
+        }
         tools.raptor(
             msg.guild.id,
             msg.channel,

--- a/index.js
+++ b/index.js
@@ -426,10 +426,14 @@ const cmdList = {
   },
   reset: {
     name: 'reset',
-    description: 'Resets your daily goal',
+    example: 'reset 40 lines',
+    description:
+      'Resets your daily goal to [goal], with optional [lines|pages|minutes].' +
+      '  If no new goal is specified, removes your daily goal.',
+    usage: '[goal] [lines|pages|minutes]',
     type: 'goals',
     process: function(client, msg, suffix) {
-      goals.resetGoal(msg);
+      goals.resetGoal(msg, suffix);
     },
   },
   goalinfo: {


### PR DESCRIPTION
# Description of pull request

When a user posts a total for a war, Winnie now checks to see whether the type of total matches the type of goal the user has set.  If it does, Winnie adds the total to the user's goal progress.  Additionally, goals can now be reset without an intermediate step, and keeps the user's progress if the goal is of the same type.  This can be done by using the `!reset` command with the same syntax as the `!set` command.

# Issues Resolved

Resolves issues #29 and #47.
