### PR TITLE
The break between wars in a chain can now be set for each war.

### DIFF
--- a/challenges/chainwar.js
+++ b/challenges/chainwar.js
@@ -43,7 +43,7 @@ class ChainWar extends Challenge {
         creator,
         warName + ' (' + current + '/' + total + ')',
         initStamp,
-        countdown,
+        countdown[current - 1],
         duration,
         channel,
         'chain war',
@@ -55,6 +55,7 @@ class ChainWar extends Challenge {
     this.current = current;
     this.total = total;
     this.chainTotal = chainTotal;
+    this.countdownList = countdown;
     if (this.state == 2) {
       this.state = 3;
     }
@@ -65,7 +66,7 @@ class ChainWar extends Challenge {
       startTime: this.initStamp,
       current: this.current,
       total: this.total,
-      countdown: this.countdown,
+      countdown: this.countdownList,
       duration: this.duration,
       channel: this.channelID,
       hookedChannels: this.hookedChannels,

--- a/challenges/challenges.js
+++ b/challenges/challenges.js
@@ -414,10 +414,13 @@ class Challenges {
     }
     const chainWarCount = args.shift();
     const duration = args.shift();
-    let timeBetween = args.shift();
+    let timeBetween = args.shift().split('|');
+    while (timeBetween.length < chainWarCount) {
+      timeBetween.push(timeBetween[timeBetween.length-1]);
+    }
     let warName = args.join(' ');
     if (timeBetween === undefined) {
-      timeBetween = 1;
+      timeBetween = [1];
     }
     if (warName == '') {
       warName = msg.author.username + '\'s war';
@@ -432,11 +435,13 @@ class Challenges {
       returnMsg = '**Error:** War count must be a number. Example: `' +
           prefix +
           'chainwar 2 10 1`.';
-    } else if (isNaN(timeBetween)) {
+    } else if (timeBetween.some(isNaN)) {
       returnMsg = '**Error:** Time between wars must be a number. Example: `' +
           prefix +
           'chainwar 2 10 1`.';
-    } else if (timeBetween > 30) {
+    } else if (timeBetween.some(function(currentValue) {
+      return currentValue > 30;
+    })) {
       returnMsg = '**Error:** There cannot be more than 30 minutes' +
           ' between wars in a chain.';
     } else if (isNaN(duration)) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const tickTimer = gameloop.setGameLoop(async function(delta) {
                 startTime,
                 challengelist.challengeList[item].current + 1,
                 challengelist.challengeList[item].total,
-                challengelist.challengeList[item].countdown,
+                challengelist.challengeList[item].countdownList,
                 challengelist.challengeList[item].duration,
                 challengelist.challengeList[item].channelID,
                 challengelist.challengeList[item].hidden,


### PR DESCRIPTION
# Description of pull request

It is now possible to set the break between wars in a chain for each individual war, using the following syntax: `!chainwar 2 5 2|1`, where the pipe separates the break before the first war from the break before the second war.

# Issues Resolved

Resolves issue #26.