### PR TITLE
Update LA/commands.json to cut strings. [skip ci]

### DIFF
--- a/locales/la/commands.json
+++ b/locales/la/commands.json
@@ -116,7 +116,7 @@
     }
   },
   "server": {
-    "description": "Configurare Winnie_Bot ut obviam necessitates tuas. Administratoribus tantum -- **MANAGE SERVER** permissi.",
+    "description": "Configurare Winnie_Bot ut obviam necessitates tuas. **MANAGE SERVER** permissi.",
     "announcementsChannel": {
       "description": "Winnie_Bot hac via utitur pro nuntiis.",
       "get": {
@@ -174,7 +174,7 @@
         "description": "Elige novam linguam pro Winnie_Bot loqui.",
         "success": "Winnie_Bot nunc loquitur {{locale}}.",
         "args": {
-          "locale": "ISO 639-1 codex. Colligunt ex: `en` (English/lingua Anglica), `fr` (Français/lingua Gallica), `hu` (Magyar/lingua Hungarica), `la` (Latina/optimus lingua), `ms` (Bahasa Melayu/lingua Malaysia), `nl` (Nederlands/lingua Batavica), and `sv` (Svenska/lingua Suecica)."
+          "locale": "ISO 639-1 codex."
         },
         "error": "**Error occurrit**: Lingua quam elegisti non est. (Datorum frangitur. Superos clama!)."
       }


### PR DESCRIPTION
Removed/edited language in rows 119 & 177 to avoid the 100-character cutoff. (Rows 23 and 158 were already below 100 characters in the Latin.)

# Description of pull request

Fixes args/descriptions with more than 100 characters.

# Issues Resolved

Resolves deployment problem during testing on 17 Oct.

# Testing Performed

Katie tested with English.
